### PR TITLE
Use direct substitute hooking APIs, if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TARGET =: clang::5.0
-ARCHS = armv7 armv7s arm64
+ARCHS = armv7 armv7s arm64 arm64e
 DEBUG = 0
 
 THEOS_PACKAGE_DIR_NAME = debs

--- a/control
+++ b/control
@@ -6,8 +6,8 @@ Homepage: https://cydia.akemi.ai/
 Provides: appsync
 Replaces: us.hackulo.appsync50
 Package: net.angelxwind.appsyncunified
-Name: AppSync Unified (NO A12 SUPPORT)
-Version: 41.0-NoA12
+Name: AppSync Unified
+Version: 41.0
 Architecture: iphoneos-arm
 Description: Enables the ability to install unsigned/fakesigned iOS applications.
 Section: Tweaks


### PR DESCRIPTION
This will ensure arm64e support which is relevant for Chimera-jailbroken devices.