### PR TITLE
Silence -Wmodule-import-in-extern-c warning

### DIFF
--- a/AppSyncUnified-installd/dump.h
+++ b/AppSyncUnified-installd/dump.h
@@ -1,8 +1,8 @@
+#include <CoreFoundation/CoreFoundation.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <CoreFoundation/CoreFoundation.h>
 
 int copyEntitlementDataFromFile(const char *path, CFMutableDataRef output);
 


### PR DESCRIPTION
To be entirely honest I don't quite understand how this works but I'm guessing CoreFoundation is marked "extern_c" or something already.