### PR TITLE
Update compatibility to iOS 18.7.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2014-2024 Karen/あけみ, Linus Yang
+Copyright (C) 2014-2025 Karen/あけみ, Linus Yang
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/appinst/appinst.m
+++ b/appinst/appinst.m
@@ -101,7 +101,7 @@ bool isSafeToDeleteAppInstTemporaryDirectory(NSString *workPath) {
 int main(int argc, const char *argv[]) {
 	@autoreleasepool {
 		printf("appinst (App Installer)\n");
-		printf("Copyright (C) 2014-2024 Karen/あけみ\n");
+		printf("Copyright (C) 2014-2025 Karen/あけみ\n");
 		printf("** PLEASE DO NOT USE APPINST FOR PIRACY **\n");
 		if (access(DPKG_PATH, F_OK) == -1) {
 			printf("You seem to have installed appinst from an APT repository that is not cydia.akemi.ai.\n");

--- a/asu_inject/asu_inject.c
+++ b/asu_inject/asu_inject.c
@@ -96,7 +96,7 @@ static void inject_dylib(const char *name, pid_t pid, const char *dylib) {
 
 int main(int argc, char *argv[]) {
 	printf("asu_inject for AppSync Unified\n");
-	printf("Copyright (C) 2014-2024 Karen/あけみ\n");
+	printf("Copyright (C) 2014-2025 Karen/あけみ\n");
 	if (access(DPKG_PATH, F_OK) == -1) {
 		printf("You seem to have installed AppSync Unified from an APT repository that is not cydia.akemi.ai.\n");
 		printf("Please make sure that you download AppSync Unified from the official repository to ensure proper operation.\n");

--- a/changelog-inline.html
+++ b/changelog-inline.html
@@ -1,4 +1,9 @@
 			<panel>
+				<label>118.0: 2025/10/04</label>
+				<fieldset>
+					<div><label>Added support for all iOS versions up to iOS 18.7.1.</label></div>
+					<div><label>No other changes were made to AppSync Unified's functionality or code.</label></div>
+				</fieldset>
 				<label>116.0: 2024/11/28</label>
 				<fieldset>
 					<div><label>Added support for all iOS versions up to iOS 18.2.</label></div>

--- a/control
+++ b/control
@@ -7,7 +7,7 @@ Provides: appsync, net.angelxwind.appsyncunified
 Replaces: us.hackulo.appsync50, net.angelxwind.appsyncunified
 Package: ai.akemi.appsyncunified
 Name: AppSync Unified
-Version: 116.0
+Version: 118.0
 Architecture: iphoneos-arm
 Description: Enables the ability to install unsigned/fakesigned iOS applications.
 Section: Tweaks

--- a/control
+++ b/control
@@ -1,5 +1,5 @@
 Conflicts: us.hackulo.appsync50, us.hackulo.appsync50plus, com.hackyouriphone.appsync7, com.teiron.ppsync, appsync50plus2.25pp, com.linusyang.appsync, com.sull.appsyncunified, com.sull.appsyncunifiedbeta, com.xsellize.appsync50, com.xsellize.appsync50plus, appsync50plus.178, appsync50plus2.178, cydia.net.angelxwind.appsyncunified, com.ifucker.appsync, com.sexyphonetech.appsyncunified, appsyncunifiedofficial, org.digbick.asufixed, cn.mingmei.asu623517234615234813, technology.goated.appsync, technology.goated.appsyncunified, vaginalfisting.appsynctool, science.xnu.substitute, akemi.appsink, akemi.appsyncunifed, akemi.appsyncunifed2, akemi.appsyncunifedpatched, appsyncpatched, appsyncrootless, weaponized.autism.technology.appsyncunified, ellekit (< 1.1)
-Depends: firmware (>= 5.0), mobilesubstrate (>= 0.9.5100), firmware (<= 18.2)
+Depends: firmware (>= 5.0), mobilesubstrate (>= 0.9.5100), firmware (<= 18.7.1)
 Depiction: https://cydia.akemi.ai/?page/ai.akemi.appsyncunified
 Maintainer: Karen/あけみ <karen@akemi.ai>
 Homepage: https://cydia.akemi.ai/

--- a/pkg-actions/pkg-actions.m
+++ b/pkg-actions/pkg-actions.m
@@ -59,7 +59,7 @@ int main(int argc, const char **argv) {
 			LOG("Running prerm…\n");
 		#endif
 		printf("AppSync Unified\n");
-		printf("Copyright (C) 2014-2024 Karen/あけみ\n");
+		printf("Copyright (C) 2014-2025 Karen/あけみ\n");
 		printf("** PLEASE DO NOT USE APPSYNC UNIFIED FOR PIRACY **\n");
 		if (access(DPKG_PATH, F_OK) == -1) {
 			printf("You seem to have installed AppSync Unified from an APT repository that is not cydia.akemi.ai.\n");

--- a/redditpost.md
+++ b/redditpost.md
@@ -8,9 +8,9 @@ Any support is _greatly_ appreciated, but donations are *not* and will *never* b
 
 ---
 
-# Changelog for 116.0 ([full changelog](https://cydia.akemi.ai/?page/ai.akemi.appsyncunified-changelog))
+# Changelog for 118.0 ([full changelog](https://cydia.akemi.ai/?page/ai.akemi.appsyncunified-changelog))
 
-* Added support for all iOS versions up to iOS 18.2.
+* Added support for all iOS versions up to iOS 18.7.1.
 * No other changes were made to AppSync Unified's functionality or code.
 
 ---


### PR DESCRIPTION
Hi!

I manually tested ASU v116.0 on iOS 18.7.1 by updating the `firmware` dependency in the `control` file an repackaging the deb, and can confirm it works perfectly!

Tested on:
- iPad 7th gen (A2197)
- iOS 18.7.1 (22H31)
- rootless JB with palera1n v2.2.1 

To save you some work, I checked what you did the last version bump and did that for you (hope it's ok):
- Bumped version to 118
- Updated the changelogs
- Updated copyrights to 2025