### PR TITLE
Have a separate control file for rootless

### DIFF
--- a/control-rootless
+++ b/control-rootless
@@ -1,5 +1,5 @@
 Conflicts: us.hackulo.appsync50, us.hackulo.appsync50plus, com.hackyouriphone.appsync7, com.teiron.ppsync, appsync50plus2.25pp, com.linusyang.appsync, com.sull.appsyncunified, com.sull.appsyncunifiedbeta, com.xsellize.appsync50, com.xsellize.appsync50plus, appsync50plus.178, appsync50plus2.178, cydia.net.angelxwind.appsyncunified, com.ifucker.appsync, com.sexyphonetech.appsyncunified, appsyncunifiedofficial, org.digbick.asufixed, cn.mingmei.asu623517234615234813, technology.goated.appsync, technology.goated.appsyncunified, vaginalfisting.appsynctool, science.xnu.substitute, akemi.appsink, akemi.appsyncunifed, akemi.appsyncunifed2, akemi.appsyncunifedpatched, appsyncpatched, appsyncrootless, weaponized.autism.technology.appsyncunified, ellekit (<< 1.1)
-Depends: firmware (>= 5.0), mobilesubstrate (>= 0.9.5100), firmware (<< 26.0)
+Depends: firmware (>= 15.0), mobilesubstrate (>= 0.9.5100), firmware (<< 26.0)
 Depiction: https://cydia.akemi.ai/?page/ai.akemi.appsyncunified
 Maintainer: Karen/あけみ <karen@akemi.ai>
 Homepage: https://cydia.akemi.ai/


### PR DESCRIPTION
- Use a separate control file for the rootless package to fix an issue where AppSync wouldn't install via Cydia on 64-bit devices running older iOS (7-10, Cydia/Telesphoreo)
    - The only change is setting firmware `(>= 15.0)` for rootless instead of `(>= 5.0)`
    - Not really sure why this fixes it, but it resolves the install issue
- Fix ElleKit version warning by changing `(< 1.1)` to `(<< 1.1)`
- Bump firmware to `(<< 26.0)` to cover all iOS 18 versions (iPad 7 on palera1n)